### PR TITLE
Changes for Scouting America Rebrand & LOOA Compliance 

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -1,47 +1,17 @@
-- title: Dues Early Bird Ends
-  date: 2025-01-31
-  date-end:
-  r-closes:
-  time:
-  price:
-  location: UnamiLodge.org
-  location-url:
-  link-text: Pay My Dues
-  link-url: https://scoutingevent.com/525-91020
-  post-url:
-  ordeal: false
-  brotherhood: false
-  highlight: true
-
-- title: Chapter Unit Elections & Lodgemaster Training
-  date: 2025-02-22
-  date-end:
-  r-closes: 2025-02-15
-  time: 9AM-1PM
-  price: 0
-  location: COL Council Office
-  location-url: https://maps.app.goo.gl/xABdiVPFFqXHUubj7
-  link-text: Register Now
-  link-url: https://forms.gle/3iRVt8sSJhuUAPMv6
-  post-url:
-  ordeal: false
-  brotherhood: false
-  highlight: true
-
 - title: Community Service Day
   date: 2025-03-22
   date-end:
-  r-closes:
-  time:
-  price:
-  location: TBD
+  r-closes: 2025-03-21
+  time: 8:30 AM - 12 PM
+  price: 0
+  location: Various
   location-url:
-  link-text:
-  link-url:
+  link-text: Register Now
+  link-url: https://scoutingevent.com/525-95126
   post-url:
   ordeal: false
   brotherhood: false
-  highlight: false
+  highlight: true
 
 - title: Turtle Pass Closes
   date: 2025-03-31
@@ -84,9 +54,9 @@
   link-text: Register Now
   link-url: https://scoutingevent.com/525-94122
   post-url:
-  ordeal: false
-  brotherhood: false
-  highlight: false
+  ordeal: true
+  brotherhood: true
+  highlight: true
 
 - title: Spring Service 2
   date: 2025-05-16
@@ -99,8 +69,8 @@
   link-text: Register Now
   link-url: https://scoutingevent.com/525-94122
   post-url:
-  ordeal: false
-  brotherhood: false
+  ordeal: true
+  brotherhood: true
   highlight: false
 
 - title: Camp Hart 95th Anniversary
@@ -129,8 +99,8 @@
   link-text: Register Now
   link-url: https://scoutingevent.com/525-94122
   post-url:
-  ordeal: false
-  brotherhood: false
+  ordeal: true
+  brotherhood: true
   highlight: false
 
 - title: Section E17 Conclave
@@ -189,8 +159,8 @@
   link-text: Register Now
   link-url: https://scoutingevent.com/525-94122
   post-url:
-  ordeal: false
-  brotherhood: false
+  ordeal: true
+  brotherhood: true
   highlight: false
 
 - title: Brotherhood Blitz

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -13,6 +13,21 @@
   brotherhood: false
   highlight: true
 
+- title: Chapter Unit Elections & Lodgemaster Training
+  date: 2025-02-22
+  date-end:
+  r-closes: 2025-02-15
+  time: 9AM-1PM
+  price: 0
+  location: COL Council Office
+  location-url: https://maps.app.goo.gl/xABdiVPFFqXHUubj7
+  link-text: Register Now
+  link-url: https://forms.gle/3iRVt8sSJhuUAPMv6
+  post-url:
+  ordeal: false
+  brotherhood: false
+  highlight: true
+
 - title: Community Service Day
   date: 2025-03-22
   date-end:

--- a/_data/lec.yml
+++ b/_data/lec.yml
@@ -166,13 +166,13 @@ committees:
   email: unitelections
   members:
   - title: Co-Chair
-    name: Samuel E.
+    name: Marina D.
   - title: Co-Chair
     name: Douglas L.
-  - title: Adviser
+  - title: Co-Adviser
     name: David "Doc" Sirken
-  - title: Adviser
-    name: Andrew B.
+  - title: Co-Adviser
+    name: Andrew Barnett
 
 - committee-name: Membership
   email: membership
@@ -310,6 +310,6 @@ committees:
   - title: Co-Chair
     name: Douglas L.
   - title: Co-Chair
-    name: Marina C.
+    name: Marina D.
   - title: Adviser
     name: Bob Deck

--- a/leadership-oaha.md
+++ b/leadership-oaha.md
@@ -4,9 +4,9 @@ layout: page
 permalink: /scholarship/
 ---
 
-Unami Lodge, One offers a High Adventure and National Events Scholarship to youth Arrowmen of our Lodge by up to $250 to attend one of the National Order of the Arrow High Adventure Programs at Philmont Scout Ranch, Northern Tier, and the Florida High Adventure Sea Base or a National Event, like National Order of the Arrow Conference (NOAC).
+Unami Lodge, One offers a High Adventure and National Events Scholarship to youth Arrowmen of our lodge by up to $250 to attend one of the National Order of the Arrow High Adventure programs at Philmont Scout Ranch, Northern Tier, Summit Bechtel Reserve, and the Florida High Adventure Sea Base or a National Event, like National Order of the Arrow Conference (NOAC).
 
-This scholarship is reserved for those individuals who exhibit interest and service as well as a future commitment to the Order of the Arrow and Unami Lodge, One. It is expected of the recipients to continue their service in the OA as well as bring their enthusiasm gained from these programs back to our lodge, your chapter, and unit. Each recipient will be required at the end of their experience to provide the Lodge with an account of their experiences that can be posted on the Lodge website for recognition and promotion for the programs and the scholarship.
+This scholarship is reserved for those individuals who exhibit interest and service as well as a future commitment to the Order of the Arrow and Unami Lodge, One. It is expected of the recipients to continue their service in the OA as well as bring their enthusiasm gained from these programs back to our lodge, your chapter, and unit. Each recipient will be required at the end of their experience to provide the lodge with an account of their experiences that can be posted on the lodge website for recognition and promotion for the programs and the scholarship.
 
 <div class="text-center my-5">
   <a href="/files/OAHA_Scholarship.pdf" class="btn btn-primary"> Apply Now!</a>

--- a/membership-electedcandidates.md
+++ b/membership-electedcandidates.md
@@ -11,11 +11,11 @@ Hopefully, this page answers them all for you, and prepares you for the next ste
 journey!
 
 <h2>What is the Order of the Arrow?</h2>
-The Order of the Arrow is Scouting’s National Honor Society. Each local BSA council has their own group of the
+The Order of the Arrow is Scouting’s National Honor Society. Each local Scouting America council has their own group of the
 Order of the Arrow called a lodge. Our lodge, Unami Lodge, One is the first lodge founded. In 1915, Dr. E. Urner
 Goodman and Carroll A. Edson began the Order of the Arrow at Treasure Island Camp to recognize those Scouts
 and Scouters who best exemplified the Scout Oath and Scout Law in their daily life – just like you! In 1948, the
-Order of the Arrow became an official program of the Boy Scouts of America. In 2019, membership in the Order of
+Order of the Arrow became an official program of Scouting America. In 2019, membership in the Order of
 the Arrow expanded to welcome new members from Scouts BSA troops, Venturing crews, and Sea Scout ships,
 both male and female participants alike.
 


### PR DESCRIPTION
Changed all references of Boy Scouts of America to Scouting America on the Elected Candidates page.