### PR TITLE
Update oa-bsa.org links to oa-scouting.org

### DIFF
--- a/_includes/page_footer.html
+++ b/_includes/page_footer.html
@@ -13,7 +13,7 @@
         <h4>Resources</h4>
         <ul class="footer-links" style="list-style: none; margin-left: -30px;">
           <li><a href="https://scoutingphilly.org/">Cradle of Liberty Council</a></li>
-          <li><a href="https://sectione17.oa-bsa.org/">Section E17</a></li>
+          <li><a href="https://e17.oa-scouting.org/">Section E17</a></li>
           <li><a href="https://oa-scouting.org/eastern/">Eastern Region</a></li>
           <li><a href="https://www.oa-scouting.org/">National OA</a></li>
           <li><a href="https://www.scouting.org">Scouting America</a></li>

--- a/about-noac.md
+++ b/about-noac.md
@@ -92,7 +92,7 @@ banner: /img/portals/noac-2024-portal.png
       Scholarships are available to youth (under 21) members of the lodge to help offset the cost of NOAC. Each scholarship has it's own application and review process. Be sure to check the due date for each individually. 
       <ul>
         <li><strong>Unami Lodge</strong> - <a href="/scholarship/">OA High Adventure Scholarship</a></li>
-        <li><strong>Section E17</strong> - <a href="https://sectione17.oa-bsa.org/scholarships/bhs-scholarship/">Brian H. Swatt Memorial National Events Scholarship</a></li>
+        <li><strong>Section E17</strong> - <a href="https://e17.oa-scouting.org/scholarships/bhs-scholarship/">Brian H. Swatt Memorial National Events Scholarship</a></li>
         <li><strong>National OA</strong> - <a href="https://surveys.qualtrics.charlotte.edu/jfe/form/SV_bmvRrppiB4x2H7U">Trailblazer Scholarship</a></li>
       </ul>
     </p>

--- a/kb.md
+++ b/kb.md
@@ -59,7 +59,7 @@ Absolutely!  Please do not hesitate to reach out to communications@unamilodge.or
 <table class="table">
   <tr>
     <td class="align-middle"><h5 class="my-0">OA LodgeMaster</h5>Manage members, events, and chapter communication all from one place!</td>
-    <td class="align-middle text-md-right"><a class="btn btn-primary" target="_blank" href="https://lodgemaster-client.oa-bsa.org">Link</a></td>
+    <td class="align-middle text-md-right"><a class="btn btn-primary" target="_blank" href="https://lodgemaster-client.oa-scouting.org">Link</a></td>
   </tr>
 </table>
 
@@ -91,7 +91,7 @@ Absolutely!  Please do not hesitate to reach out to communications@unamilodge.or
       <h5 class="my-0">LodgeMaster Email</h5>
       Email your chapter or relatively small segment of the Lodge from the platform we all know and love.
     </td>
-    <td class="align-middle text-md-right"><a class="btn btn-primary" target="_blank" href="https://confluence.oa-bsa.org/display/OALMLC4/Send+email+to+all+of+your+chapter+members">Read More</a></td>
+    <td class="align-middle text-md-right"><a class="btn btn-primary" target="_blank" href="https://confluence.oa-scouting.org/display/OALMLC4/Send+email+to+all+of+your+chapter+members">Read More</a></td>
   </tr>
   <tr>
     <td class="align-middle">

--- a/membership-dues.md
+++ b/membership-dues.md
@@ -36,14 +36,14 @@ Currently, new portal accounts are automatically issued to newly-elected candida
 
 ## Already have access the Member Portal
 
-Once you’ve linked your account, you can get to the member portal by going to [portal.oa-bsa.org](https://portal.oa-bsa.org/)
+Once you’ve linked your account, you can get to the member portal by going to [portal.oa-scouting.org](https://portal.oa-scouting.org/)
 
 ## Do not have a Member Portal account, see below
 ### Get an Arrow ID account
 
 The Order of the Arrow has a single-sign-on system called Arrow ID which is used to access any official Order of the Arrow resources (such as the national registration system used for NOAC and NLS/DYLC, LodgeMaster, and the Member Portal). If you’ve ever attended NOAC or NLS, you probably already have an account. You will need an Arrow ID account first before you can access the Member Portal.
 
-1. Go to [id.oa-bsa.org/Account/Register](https://id.oa-bsa.org/Account/Register)
+1. Go to [id.oa-scouting.org/Account/Register](https://id.oa-scouting.org/Account/Register)
 2. Fill in your name, your email address, and the password you want to use for your account and submit the form.
 3. Click **Register**.
 4. Follow any directions given to complete your registration.

--- a/portal-unitelections.md
+++ b/portal-unitelections.md
@@ -35,7 +35,7 @@ Elected candidates, both youth and adult, will receive further information from 
 <div class="alert alert-secondary">
   <strong>Election Teams:</strong>
   <p class='my-3'>
-    As a reminder, Unami Lodge has retired our previous Google Forms for reporting election results in favor of the new Inductions Module built into <a href="https://lodgemaster-client.oa-bsa.org/">LodgeMaster</a>. Please contact the Unit Elections committee if you need help accessing or entering elections.
+    As a reminder, Unami Lodge has retired our previous Google Forms for reporting election results in favor of the new Inductions Module built into <a href="https://lodgemaster-client.oa-scouting.org/">LodgeMaster</a>. Please contact the Unit Elections committee if you need help accessing or entering elections.
   </p>
   <p class='my-3'>
     Additionally, please enter election results in a timely manner. Unit leaders cannot submit adult nominations until youth results have been entered and approved. The Inductions Module does not notify any youth candidates of their election until the call-out date has been reached.


### PR DESCRIPTION
Updates refrences to oa-bsa.org in everything exept posts to oa-scouting.

This Includes:
- lodgemaster-client.oa-bsa.org --> lodgemaster-client.oa-scouting.org
- confluence.oa-bsa.org --> confluence.oa-scouting.org
- id.oa-bsa.org --> is.oa-scouting.org
- sectione17.oa-bsa.org --> e17.oa-scouting.org (to follow the new structure)